### PR TITLE
feat: expose update method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,10 @@ export const attach = (element: HTMLTextAreaElement) => {
   Object.defineProperty(element, "value", {
     ...descriptor,
     set() {
-      descriptor?.set?.apply<unknown, unknown[], unknown>(
+      descriptor?.set?.apply(
         this,
         // eslint-disable-next-line prefer-rest-params
-        arguments as unknown as unknown[]
+        arguments as unknown as [unknown]
       );
       inputHandler();
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,24 @@ export const attach = (element: HTMLTextAreaElement) => {
 
   element.addEventListener("input", inputHandler);
 
+  const elementPrototype = Object.getPrototypeOf(element);
+  const descriptor = Object.getOwnPropertyDescriptor(elementPrototype, "value");
+  Object.defineProperty(element, "value", {
+    ...descriptor,
+    set() {
+      descriptor?.set?.apply<unknown, unknown[], unknown>(
+        this,
+        // eslint-disable-next-line prefer-rest-params
+        arguments as unknown as unknown[]
+      );
+      inputHandler();
+    },
+  });
   return {
     detach() {
       element.removeAttribute(ATTRIBUTE_NAME);
       element.removeEventListener("input", inputHandler);
     },
+    update: inputHandler,
   };
 };


### PR DESCRIPTION
When changing textarea value directly it is not resizing itself, instead of mounting observers and make bigger library I believe that just exposing `update` method will help users controls sizing of autoresize. 
Useful especially in frameworks where model is often change directly.