### PR TITLE
fix: update module paths inside package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "sideEffects": false,
   "source": "src/index.ts",
   "exports": {
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
+    "require": "./dist/index.js",
+    "default": "./dist/index.modern.mjs"
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "unpkg": "./dist/index.umd.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
With new microbundle output is different, this PR adjust module directions https://github.com/developit/microbundle/releases/tag/v0.15.0
PR changes behaviour in microbundle https://github.com/developit/microbundle/pull/950

Current bundle output
<img width="377" alt="image" src="https://user-images.githubusercontent.com/2566152/174316269-7dbb61b0-bf67-46a7-89f8-348af8a34780.png">
